### PR TITLE
Protocol handler refactor and multithreading

### DIFF
--- a/README
+++ b/README
@@ -31,9 +31,7 @@ and run the "sample" script that comes with mc-crusher. mc-crusher makes no
 attempt to care about what it does. It flails tiredlessly against the fanged
 defenses of the cache daemon.
 
-Modify bench-sample to print what you are most interested in examining. Start
-multiple instances of mc-crusher if you think memcached can take more. In the
-future threads will be used for user convenience.
+Modify bench-sample to print what you are most interested in examining.
 
 You can change the "default" destination ip/port by adding extra arguments:
 $ ./mc-crusher ./conf/loadconf 192.168.1.1 11211

--- a/README
+++ b/README
@@ -19,11 +19,12 @@ $ ./mc-crusher ./conf/loadconf
 Running
 -------
 
-This guy is extremely rough. It has hardcoded values such as a 200,000 item
-iteration loop. I'm releasing it early for shiggles.
+This tool is extremely rough.
 
 First, run it for a few seconds with a config like "conf/loadconf", this will
 seed the instance with some values to fetch later. Now, kill it.
+
+You can also use the bench-warmer.pl tool to preload some keys.
 
 Pick a config file, and start it as above. You should start a fresh memcached,
 and run the "sample" script that comes with mc-crusher. mc-crusher makes no
@@ -33,6 +34,9 @@ defenses of the cache daemon.
 Modify bench-sample to print what you are most interested in examining. Start
 multiple instances of mc-crusher if you think memcached can take more. In the
 future threads will be used for user convenience.
+
+You can change the "default" destination ip/port by adding extra arguments:
+$ ./mc-crusher ./conf/loadconf 192.168.1.1 11211
 
 Configuration
 -------------
@@ -81,18 +85,11 @@ key_randomize : if using prealloc'ed keys, shuffle the list after generating
 Caveats
 -------
 
-- I bundled the protocol_binary.h header because I'm an asshole, deal with it.
-
-- Hardcoded to hit a localhost instance. Just recompile if you want it
-elsehwere.
+- I bundled the protocol_binary.h header. It will need to be copied from the
+  primary repo for updates.
 
 - Does not make any attempt to safely parse the config file. If you don't type
   it exactly right you will end up with bizarre failures.
-
-- It is missing many features I intend to add and use; however as is it was
-  able to verify some lock scaling patches I worked on.
-
-- It mindlessly iterates through 200,000 keys.
 
 - It only works well with small values
 

--- a/compile
+++ b/compile
@@ -1,4 +1,4 @@
 #!/bin/bash
 # I violate the laws of reason.
 rm -f mc-crusher
-gcc -g -O2 -o mc-crusher ./mc-crusher.c -levent
+gcc -g -O2 -pthread -o mc-crusher ./mc-crusher.c -levent

--- a/conf/asciiconf
+++ b/conf/asciiconf
@@ -1,1 +1,1 @@
-send=ascii_get,recv=blind_read,conns=50,key_prefix=foobar,key_prealloc=1
+send=ascii_get,recv=blind_read,conns=50,key_prefix=foobar,key_prealloc=1,pipelines=8

--- a/conf/asciiconf
+++ b/conf/asciiconf
@@ -1,1 +1,1 @@
-send=ascii_get,recv=blind_read,conns=50,key_prefix=foobar,key_prealloc=1,pipelines=8
+send=ascii_get,recv=blind_read,conns=50,key_prefix=foobar,key_prealloc=0,pipelines=8

--- a/conf/loadconf
+++ b/conf/loadconf
@@ -1,1 +1,1 @@
-send=ascii_set,recv=blind_read,conns=5,key_prefix=foobar,value_size=2,value=hi,key_prealloc=0
+send=ascii_set,recv=blind_read,conns=5,key_prefix=foobar,value_size=2,value=hi,key_prealloc=1

--- a/mc-crusher.c
+++ b/mc-crusher.c
@@ -259,8 +259,6 @@ static void bin_prep_setq(struct connection *c) {
  * Binprot is just unwieldy in C, or I haven't figured out how to use it
  * simply yet.
  */
-/* FIXME: SETQ doesn't work since it needs to stay in sending mode post-write,
- * and the top level writer is hardcoded to swap to reader right now. */
 static void bin_write_to_client(void *arg) {
     struct connection *c = arg;
     struct iovec *vecs = c->vecs;

--- a/mc-crusher.c
+++ b/mc-crusher.c
@@ -68,9 +68,7 @@ struct connection {
     enum conn_states state;
     short ev_flags;
 
-    /* Counters, bits, flags for individual senders/getters .
-     * This isn't a union because who gives a shit.
-     */
+    /* Counters, bits, flags for individual senders/getters. */
     int mget_count;                /* # of ascii mget keys to send at once */
     unsigned char key_prefix[240];
     int value_size;
@@ -577,7 +575,6 @@ static void init_bin_get(struct connection *t) {
 }
 
 static void init_bin_getq(struct connection *t) {
-    /* lulz */
     init_bin_get(t);
     t->bin_get_pkt.message.header.request.opcode = PROTOCOL_BINARY_CMD_GETQ;
 }

--- a/mc-crusher.c
+++ b/mc-crusher.c
@@ -803,6 +803,7 @@ int main(int argc, char **argv)
     while (fgets(line, 4096, cfd) != NULL) {
         parse_config_line(main_thread, line);
     }
+    fclose(cfd);
 
     create_thread(main_thread);
     pthread_join(main_thread->thread_id, NULL);


### PR DESCRIPTION
(will probably squash branch a bit prior to move).

This series is aimed at allowing mc-crusher to run in a more automated fashion, ie; a script manages the program and runs a list of tests. This required having timed runs, internal multithreading (vs me just running N of them), and an internal cleanup.

The protocol handlers are refactored to be much simpler and have a unified codepath for pipelining and preallocated buffers. Any command can now be pipelined up to N times, and new commands can be added much more easily.